### PR TITLE
Fix sharing Cargo.lock in updating jsonschema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "generate_json_schema"
+version = "0.1.0"
+dependencies = [
+ "dprint-plugin-typstyle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ typstyle-core = { version = "0.13.0", default-features = false }
 
 [lib]
 crate-type = ["lib", "cdylib"]
+
+[workspace]
+resolver = "2"
+members = ["generate_json_schema"]

--- a/generate_json_schema/Cargo.toml
+++ b/generate_json_schema/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "generate_json_schema"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dprint-plugin-typstyle = { path = ".." }

--- a/generate_json_schema/src/main.rs
+++ b/generate_json_schema/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", dprint_plugin_typstyle::generate_json_schema());
+}

--- a/scripts/generate_json_schema.rs
+++ b/scripts/generate_json_schema.rs
@@ -1,9 +1,0 @@
-#!/usr/bin/env -S cargo -q -Zscript
----
-[dependencies]
-dprint-plugin-typstyle = { path = ".." }
----
-
-fn main() {
-    println!("{}", dprint_plugin_typstyle::generate_json_schema());
-}

--- a/scripts/normalize_json_schema.bash
+++ b/scripts/normalize_json_schema.bash
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 version="$(yq '.package.version' Cargo.toml)"
-./scripts/generate_json_schema.rs |
+cargo run --package generate_json_schema |
 	yq --output-format json "del(.required, .title) |
 		.\"\$id\" = \"https://plugins.dprint.dev/kachick/typstyle/${version}/schema.json\" |
 		.additionalProperties = false" >./deployment/schema.json

--- a/scripts/normalize_json_schema.bash
+++ b/scripts/normalize_json_schema.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euxo pipefail
+
 version="$(yq '.package.version' Cargo.toml)"
 ./scripts/generate_json_schema.rs |
 	yq --output-format json "del(.required, .title) |

--- a/scripts/test-jsonschema.bash
+++ b/scripts/test-jsonschema.bash
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -euxo pipefail
+
 jsonschema-cli deployment/schema.json --instance <(yq --output-format json '.typst' ./tests/all/dprint.json)


### PR DESCRIPTION
- **Set errors options in bash scripts, however this does not stop on cargo-script errors**
- **Replace cargo-script with workspace bin for sharing Cargo.lock**

Fixes #103
