### PR TITLE
Bump rust tooling with unstable nixpkgs channel

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,15 +37,7 @@
                 nixfmt-rfc-style
                 nil
                 go-task
-
                 typos
-
-                rustc
-                cargo
-                rustfmt
-                rust-analyzer
-                clippy
-
                 yq-go
               ])
               ++ (with unstables; [
@@ -53,10 +45,15 @@
                 typst
                 typstyle
                 jsonschema-cli
+                rustc
+                cargo
+                rustfmt
+                rust-analyzer
+                clippy
               ])
               ++ [ selfup.packages.${system}.default ];
 
-            nativeBuildInputs = with pkgs; [
+            nativeBuildInputs = with unstables; [
               rustc-wasm32.llvmPackages.bintools # rust-lld
             ];
 


### PR DESCRIPTION
Rust tooling requires unstable channel if I follow upstream crate
Because of nixpkgs doesn't backport rustc for stable channel

ref: https://github.com/kachick/dprint-plugin-typstyle/pull/105, https://github.com/kachick/dprint-plugin-typstyle/issues/103