### PR TITLE
Extract package.nix from flake to clarify minimized buildInputs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,15 +49,15 @@ jobs:
             target/
           key: ${{ runner.os }}-flake-${{ hashFiles('flake.lock', '**/*.nix') }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-flake-${{ hashFiles('flake.lock', '**/*.nix') }}-
-      - run: nix develop --command task build
+      - run: nix build
+      - run: tree -h result/
       - name: Upload WASM file as an artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           if-no-files-found: error
           name: 'dist'
           path: |
-            target/wasm32-unknown-unknown/release/dprint_plugin_typstyle.wasm
-            deployment/schema.json
+            result/share
 
   flake:
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .direnv
-
+/result
 
 # Added by cargo
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,18 @@
     in
     {
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
+          dprint-plugin-typstyle = pkgs.callPackage ./package.nix { };
+          default = dprint-plugin-typstyle;
+        }
+      );
+
       devShells = forAllSystems (
         system:
         let

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,59 @@
+{
+  pkgs,
+  lib,
+  rustPlatform,
+}:
+
+let
+  wasmTarget = "wasm32-unknown-unknown";
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dprint-plugin-typstyle";
+  version = with builtins; (fromTOML (readFile ./Cargo.toml)).package.version;
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./src
+      ./generate_json_schema
+      ./Cargo.toml
+      ./Cargo.lock
+      ./LICENSE
+      ./scripts
+      ./deployment
+    ];
+  };
+
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeBuildInputs = with pkgs; [
+    rustc-wasm32.llvmPackages.bintools # rust-lld
+    yq-go
+  ];
+
+  # https://gburghoorn.com/posts/just-nix-rust-wasm/
+  buildPhase = ''
+    runHook preBuild
+
+    bash "$src/scripts/normalize_json_schema.bash"
+    cargo build --release --target=${wasmTarget}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp target/${wasmTarget}/release/dprint_plugin_typstyle.wasm $out/share/plugin.wasm
+    cp deployment/schema.json $out/share/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Typst formatter plugin for dprint";
+    homepage = "https://github.com/kachick/dprint-plugin-typstyle";
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
- **Restore cargo cache if using same flake (#107)**
- **flake.lock: Update (#108)**
- **Bump actions/upload-artifact from 4.6.1 to 4.6.2 (#109)**
- **Bump flake.lock and related dependencies (#110)**
- **Bump typstyle-core from 0.13.1 to 0.13.2 with disabling experimental `reorder_import_items` (#111)**
- **Release 0.3.2**
- **flake.lock: Update (#112)**
- **Extract and add test for config and the schema (#113)**
- **Prefer pattern match for handling formatter result (#114)**
- **Reduce multiple initializations for default config**
- **Squash many use for dprint crate**
- **Update to Rust 2024 (#115)**
- **flake.lock: Update (#116)**
- **Bump actions/dependency-review-action from 4.5.0 to 4.6.0 (#117)**
- **flake.lock: Update (#118)**
- **Bump anyhow from 1.0.97 to 1.0.98 (#120)**
- **Bump typstyle-core from 0.13.2 to 0.13.3 (#119)**
- **Release 0.3.3**
- **flake.lock: Update (#121)**
- **flake.lock: Update (#122)**
- **Bump DeterminateSystems/nix-installer-action from 16 to 17 (#123)**
- **flake.lock: Update (#124)**
- **flake.lock: Update (#125)**
- **Ignore typstyle-core 0.13.4**
- **Bump typstyle-core to 0.13.5 (#127)**
- **Refresh lockfile with `cargo update` (#128)**
- **Refine flake (#130)**
- **Update config schema and release 0.3.4 (#129)**
- **Fix link in README**
- **Release 0.3.4**
- **Correct crate URL in README**
- **Update dependency g-plane/pretty_yaml to v0.5.1 (#131)**
- **Bump flake.lock and related dependencies (#132)**
- **Bump actions/dependency-review-action from 4.6.0 to 4.7.0 (#133)**
- **Bump typstyle-core from 0.13.5 to 0.13.6 (#135)**
- **Bump dependabot/fetch-metadata from 2.3.0 to 2.4.0 (#134)**
- **Bump flake.lock and related dependencies (#136)**
- **Uninstall selfup to reduce build time for devshell**
- **Extract package.nix from flake to minimize build inputs**
- **Make CI respect nix build**
